### PR TITLE
fix: add missing lines to add helm repos step

### DIFF
--- a/.github/workflows/chart-releaser.yml
+++ b/.github/workflows/chart-releaser.yml
@@ -33,7 +33,9 @@ jobs:
 
       - name: Add Helm repos
         run: |
+          cd charts/managed-identity-wallets
           helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm dependency update
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.4.0


### PR DESCRIPTION
Added missing lines based on the guide. See: https://catenax-ng.github.io/docs/guides/Helm/how-to-release-a-helm-chart#adding-the-chart-release-github-workflow