### PR TITLE
add new acapy instance, rename values and secrets, add todos

### DIFF
--- a/charts/managed-identity-wallets/Chart.yaml
+++ b/charts/managed-identity-wallets/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.18
+version: 0.6.0
 appVersion: 2.1.1
 
 dependencies:

--- a/charts/managed-identity-wallets/Chart.yaml
+++ b/charts/managed-identity-wallets/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.6.0
-appVersion: 2.1.1
+appVersion: 3.0.0
 
 dependencies:
   - name: postgresql

--- a/charts/managed-identity-wallets/templates/deployment.yaml
+++ b/charts/managed-identity-wallets/templates/deployment.yaml
@@ -82,15 +82,22 @@ spec:
           value: {{ .Values.datapool.authUrl }}
         - name: BPDM_PULL_DATA_AT_HOUR
           value: {{ .Values.datapool.refreshHour | quote }}
-        - name: ACAPY_API_ADMIN_URL
-          value: {{ .Values.acapy.adminUrl }}
         - name: ACAPY_NETWORK_IDENTIFIER
-          value: {{ .Values.acapy.networkIdentifier }}
+          value: {{ .Values.acapy.networkIdentifier }}  
+        - name: ACAPY_API_ADMIN_URL
+          value: {{ .Values.acapy.mt.adminUrl }}
         - name: ACAPY_ADMIN_API_KEY
           valueFrom:
             secretKeyRef:
               name: {{ include "managed-identity-wallets.fullname" . }}-acapy
-              key: acapy-admin-api-key
+              key: acapy-mt-admin-api-key
+        - name: ACAPY_BASE_WALLET_API_ADMIN_URL
+          value: {{ .Values.acapy.endorser.adminUrl }}
+        - name: ACAPY_BASE_WALLET_ADMIN_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "managed-identity-wallets.fullname" . }}-acapy
+              key: acapy-endorser-admin-api-key
         - name: CX_BPN
           value: {{ .Values.wallet.baseWalletBpn }}
         - name: CX_SHORT_DID
@@ -208,6 +215,8 @@ spec:
           limits:
             cpu: 250m
             memory: 256Mi
+        ports:
+        - containerPort: 8000
         command: ["/bin/bash"]
         args: ["-c", "aca-py start \
           -e $(ACAPY_ENDPOINT_URL) \
@@ -304,6 +313,8 @@ spec:
           limits:
             cpu: 250m
             memory: 256Mi
+        ports:
+        - containerPort: 8003   
         command: ["/bin/bash"]
         args: ["-c", "aca-py start \
           -e $(ACAPY_ENDPOINT_URL) \

--- a/charts/managed-identity-wallets/templates/deployment.yaml
+++ b/charts/managed-identity-wallets/templates/deployment.yaml
@@ -93,6 +93,12 @@ spec:
               key: acapy-admin-api-key
         - name: CX_BPN
           value: {{ .Values.wallet.baseWalletBpn }}
+        - name: CX_SHORT_DID
+          value: {{ .Values.wallet.baseWalletShortDid }} 
+        - name: CX_VERKEY
+          value: {{ .Values.wallet.baseWalletVerkey }} 
+        - name: CX_NAME
+          value: {{ .Values.wallet.baseWalletName }} 
         - name: REVOCATION_URL
           value: {{ .Values.revocation.revocationServiceUrl }}
         - name: REVOCATION_CREATE_STATUS_LIST_CREDENTIAL_AT_HOUR
@@ -134,67 +140,67 @@ spec:
             memory: 256Mi
         ports:
         - containerPort: 8086
-      - name: catenax-acapy
+      - name: catenax-endorser-acapy
         image: {{ .Values.acapy.imageName }}:{{ .Values.acapy.tag }}
         env:
         - name: WALLET_KEY
           valueFrom:
             secretKeyRef:
               name: {{ include "managed-identity-wallets.fullname" . }}-acapy
-              key: acapy-wallet-key
+              key: acapy-endorser-wallet-key
         - name: AGENT_WALLET_SEED
           valueFrom:
             secretKeyRef:
               name: {{ include "managed-identity-wallets.fullname" . }}-acapy
-              key: acapy-agent-wallet-seed
+              key: acapy-endorser-agent-wallet-seed
         - name: LEDGER_URL
-          value: {{ .Values.acapy.ledgerUrl }}
+          value: {{ .Values.acapy.endorser.ledgerUrl }}
         - name: LABEL
-          value: {{ .Values.acapy.label }}
+          value: {{ .Values.acapy.endorser.label }}
         - name: JWT_SECRET
           valueFrom:
             secretKeyRef:
               name: {{ include "managed-identity-wallets.fullname" . }}-acapy
-              key: acapy-jwt-secret
+              key: acapy-endorser-jwt-secret
         - name: ACAPY_ADMIN_API_KEY
           valueFrom:
             secretKeyRef:
               name: {{ include "managed-identity-wallets.fullname" . }}-acapy
-              key: acapy-admin-api-key
+              key: acapy-endorser-admin-api-key
         - name: LOG_LEVEL
-          value: {{ .Values.acapy.logLevel }}
+          value: {{ .Values.acapy.endorser.logLevel }}
         - name: ACAPY_ENDPOINT_PORT
-          value: {{ .Values.acapy.endpointPort | quote }}
+          value: {{ .Values.acapy.endorser.endpointPort | quote }}
         - name: ACAPY_ENDPOINT_URL
-          value: {{ .Values.acapy.endpointUrl }}
+          value: {{ .Values.acapy.endorser.endpointUrl }}
         - name: ACAPY_ADMIN_PORT
-          value: {{ .Values.acapy.adminPort | quote }}
+          value: {{ .Values.acapy.endorser.adminPort | quote }}
         - name: DB_HOST
           {{- if .Values.acapypostgresql.enabled }}
           value: {{ include "acapyPostgresContext" (list $ "postgresql.primary.fullname") }}
           {{- else }}
-          value: {{ .Values.acapy.databaseHost }}
+          value: {{ .Values.acapy.endorser.databaseHost }}
           {{- end }}
         - name: DB_ACCOUNT
           valueFrom:
             secretKeyRef:
               name: {{ include "managed-identity-wallets.fullname" . }}-acapy
-              key: acapy-db-account
+              key: acapy-endorser-db-account
         - name: DB_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ include "managed-identity-wallets.fullname" . }}-acapy
-              key: acapy-db-password
+              key: acapy-endorser-db-password
         - name: DB_ADMIN_USER
           valueFrom:
             secretKeyRef:
               name: {{ include "managed-identity-wallets.fullname" . }}-acapy
-              key: acapy-db-admin
+              key: acapy-endorser-db-admin
         - name: DB_ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ include "managed-identity-wallets.fullname" . }}-acapy
-              key: acapy-db-admin-password
+              key: acapy-endorser-db-admin-password
         resources:
           requests:
             cpu: 100m
@@ -209,8 +215,104 @@ spec:
           --inbound-transport http '0.0.0.0' $(ACAPY_ENDPOINT_PORT) \
           --outbound-transport http \
           --admin '0.0.0.0' $(ACAPY_ADMIN_PORT) \
-          --wallet-name AcapyCatenaX \
-          --wallet-type indy \
+          --wallet-name AcapyCatenaXEndorserWallet \
+          --wallet-type askar \
+          --wallet-key $(WALLET_KEY) \
+          --wallet-storage-type postgres_storage
+          --wallet-storage-config '{\"url\":\"$(DB_HOST):5432\",\"max_connections\":5}'
+          --wallet-storage-creds '{\"account\":\"$(DB_ACCOUNT)\",\"password\":\"$(DB_PASSWORD)\",\"admin_account\":\"$(DB_ADMIN_USER)\",\"admin_password\":\"$(DB_ADMIN_PASSWORD)\"}'
+          --seed $(AGENT_WALLET_SEED) \
+          --genesis-url $(LEDGER_URL)/genesis \
+          --label $(LABEL) \
+          --admin-api-key $(ACAPY_ADMIN_API_KEY) \
+          --auto-ping-connection \
+          --jwt-secret $(JWT_SECRET) \
+          --public-invites \
+          --endorser-protocol-role endorser \
+          --auto-endorse-transactions \
+          --log-level $(LOG_LEVEL)"
+        ]
+      - name: catenax-mt-acapy
+        image: {{ .Values.acapy.imageName }}:{{ .Values.acapy.tag }}
+        env:
+        - name: WALLET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "managed-identity-wallets.fullname" . }}-acapy
+              key: acapy-mt-wallet-key
+        - name: AGENT_WALLET_SEED
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "managed-identity-wallets.fullname" . }}-acapy
+              key: acapy-mt-agent-wallet-seed
+        - name: LEDGER_URL
+          value: {{ .Values.acapy.mt.ledgerUrl }}
+        - name: LABEL
+          value: {{ .Values.acapy.mt.label }}
+        - name: JWT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "managed-identity-wallets.fullname" . }}-acapy
+              key: acapy-mt-jwt-secret
+        - name: ACAPY_ADMIN_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "managed-identity-wallets.fullname" . }}-acapy
+              key: acapy-mt-admin-api-key
+        - name: LOG_LEVEL
+          value: {{ .Values.acapy.mt.logLevel }}
+        - name: ACAPY_ENDPOINT_PORT
+          value: {{ .Values.acapy.mt.endpointPort | quote }}
+        - name: ACAPY_ENDPOINT_URL
+          value: {{ .Values.acapy.mt.endpointUrl }}
+        - name: ACAPY_ADMIN_PORT
+          value: {{ .Values.acapy.mt.adminPort | quote }}
+        - name: DB_HOST
+          {{- if .Values.acapypostgresql.enabled }}
+          value: {{ include "acapyPostgresContext" (list $ "postgresql.primary.fullname") }}
+          {{- else }}
+          value: {{ .Values.acapy.mt.databaseHost }}
+          {{- end }}
+        - name: DB_ACCOUNT
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "managed-identity-wallets.fullname" . }}-acapy
+              key: acapy-mt-db-account
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "managed-identity-wallets.fullname" . }}-acapy
+              key: acapy-mt-db-password
+        - name: DB_ADMIN_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "managed-identity-wallets.fullname" . }}-acapy
+              key: acapy-mt-db-admin
+        - name: DB_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "managed-identity-wallets.fullname" . }}-acapy
+              key: acapy-mt-db-admin-password
+        - name: ACAPY_ENDORSER_PUBLIC_DID
+          value: {{ .Values.acapy.mt.endorserPublicDid }}
+        - name: ACAPY_WEBHOOK_URL
+          value: {{ .Values.acapy.mt.webhookUrl }}  
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 250m
+            memory: 256Mi
+        command: ["/bin/bash"]
+        args: ["-c", "aca-py start \
+          -e $(ACAPY_ENDPOINT_URL) \
+          --auto-provision \
+          --inbound-transport http '0.0.0.0' $(ACAPY_ENDPOINT_PORT) \
+          --outbound-transport http \
+          --admin '0.0.0.0' $(ACAPY_ADMIN_PORT) \
+          --wallet-name AcapyCatenaXManagedWallet \
+          --wallet-type askar \
           --wallet-key $(WALLET_KEY) \
           --wallet-storage-type postgres_storage
           --wallet-storage-config '{\"url\":\"$(DB_HOST):5432\",\"max_connections\":5}'
@@ -223,5 +325,13 @@ spec:
           --jwt-secret $(JWT_SECRET) \
           --multitenant \
           --multitenant-admin \
+          --public-invites \
+          --webhook-url $(ACAPY_WEBHOOK_URL) \
+          --endorser-protocol-role author \
+          --endorser-alias endorser \
+          --endorser-public-did $(ACAPY_ENDORSER_PUBLIC_DID) \
+          --auto-request-endorsement \
+          --auto-write-transactions \
+          --auto-promote-author-did \
           --log-level $(LOG_LEVEL)"
         ]

--- a/charts/managed-identity-wallets/templates/ingress.yaml
+++ b/charts/managed-identity-wallets/templates/ingress.yaml
@@ -31,35 +31,33 @@ spec:
     - host: {{ .Values.certificate.host }}
       http:
         paths:
+        - path: /acapy-connection-base
+          pathType: Prefix
+          backend:
+            service:
+              name: catenax-managed-identity-wallets-acapy-endorser
+              port:
+                number: 8000
+    - host: {{ .Values.certificate.host }}
+      http:
+        paths:
+        - path: /acapy-connection-mt
+          pathType: Prefix
+          backend:
+            service:
+              name: catenax-managed-identity-wallets-acapy-mt
+              port:
+                number: 8003
+    - host: {{ .Values.certificate.host }}
+      http:
+        paths:
           - path: /(.*)
             pathType: Prefix
             backend:
               service:
-                name: catenax-managed-identity-wallets
+                name: catenax-managed-identity-wallets-miw
                 port:
                   number: 8080
-    - host: {{ .Values.certificate.host }}
-      port:
-        number: 8000
-      http:
-        paths:
-          - path:
-            backend:
-              service:
-                name: catenax-managed-identity-wallets
-                port:
-                  number: 8000
-    - host: {{ .Values.certificate.host }}
-      port:
-        number: 8003
-      http:
-        paths:
-          - path:
-            backend:
-              service:
-                name: catenax-managed-identity-wallets
-                port:
-                  number: 8003
   tls:
     - hosts:
         - {{ .Values.certificate.host }}

--- a/charts/managed-identity-wallets/templates/ingress.yaml
+++ b/charts/managed-identity-wallets/templates/ingress.yaml
@@ -31,7 +31,7 @@ spec:
     - host: {{ .Values.certificate.host }}
       http:
         paths:
-          - path: /acapy-connection-base
+          - path: /didcomm-base
             pathType: Exact
             backend:
               service:
@@ -41,7 +41,7 @@ spec:
     - host: {{ .Values.certificate.host }}
       http:
         paths:
-          - path: /acapy-connection-mt
+          - path: /didcomm-managed-wallets
             pathType: Exact
             backend:
               service:

--- a/charts/managed-identity-wallets/templates/ingress.yaml
+++ b/charts/managed-identity-wallets/templates/ingress.yaml
@@ -33,9 +33,10 @@ spec:
         paths:
           - path: /acapy-connection-base
             pathType: Prefix
+            pathRewrite: /
             backend:
               service:
-                name: catenax-managed-identity-wallets
+                name: catenax-managed-identity-wallets-acapy-base
                 port:
                   number: 8000
     - host: {{ .Values.certificate.host }}
@@ -43,9 +44,10 @@ spec:
         paths:
           - path: /acapy-connection-mt
             pathType: Prefix
+            pathRewrite: /
             backend:
               service:
-                name: catenax-managed-identity-wallets
+                name: catenax-managed-identity-wallets-acapy-mt
                 port:
                   number: 8003
     - host: {{ .Values.certificate.host }}

--- a/charts/managed-identity-wallets/templates/ingress.yaml
+++ b/charts/managed-identity-wallets/templates/ingress.yaml
@@ -31,23 +31,23 @@ spec:
     - host: {{ .Values.certificate.host }}
       http:
         paths:
-        - path: /acapy-connection-base
-          pathType: Prefix
-          backend:
-            service:
-              name: catenax-managed-identity-wallets-acapy-endorser
-              port:
-                number: 8000
+          - path: /acapy-connection-base
+            pathType: Prefix
+            backend:
+              service:
+                name: catenax-managed-identity-wallets
+                port:
+                  number: 8000
     - host: {{ .Values.certificate.host }}
       http:
         paths:
-        - path: /acapy-connection-mt
-          pathType: Prefix
-          backend:
-            service:
-              name: catenax-managed-identity-wallets-acapy-mt
-              port:
-                number: 8003
+          - path: /acapy-connection-mt
+            pathType: Prefix
+            backend:
+              service:
+                name: catenax-managed-identity-wallets
+                port:
+                  number: 8003
     - host: {{ .Values.certificate.host }}
       http:
         paths:
@@ -55,7 +55,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: catenax-managed-identity-wallets-miw
+                name: catenax-managed-identity-wallets
                 port:
                   number: 8080
   tls:

--- a/charts/managed-identity-wallets/templates/ingress.yaml
+++ b/charts/managed-identity-wallets/templates/ingress.yaml
@@ -15,7 +15,8 @@ metadata:
           location ~* /list-credential/ {
               deny all;
               return 403;
-            }
+          }
+
           location ~* /webhook/topic/ {
             deny all;
             return 403;

--- a/charts/managed-identity-wallets/templates/ingress.yaml
+++ b/charts/managed-identity-wallets/templates/ingress.yaml
@@ -32,8 +32,7 @@ spec:
       http:
         paths:
           - path: /acapy-connection-base
-            pathType: Prefix
-            pathRewrite: /
+            pathType: Exact
             backend:
               service:
                 name: catenax-managed-identity-wallets-acapy-base
@@ -43,8 +42,7 @@ spec:
       http:
         paths:
           - path: /acapy-connection-mt
-            pathType: Prefix
-            pathRewrite: /
+            pathType: Exact
             backend:
               service:
                 name: catenax-managed-identity-wallets-acapy-mt

--- a/charts/managed-identity-wallets/templates/ingress.yaml
+++ b/charts/managed-identity-wallets/templates/ingress.yaml
@@ -33,9 +33,28 @@ spec:
                 name: catenax-managed-identity-wallets
                 port:
                   number: 8080
-    # TODO Acapy inbound calls should be forwared to 8000 and 8003. This is related 
-    # to the values acapy.endorser.endpointUrl and acapy.mt.endpointUrl.
-    # Mabye a new host is required to achive this
+    - host: {{ .Values.certificate.host }}
+      port:
+        number: 8000
+      http:
+        paths:
+          - path:
+            backend:
+              service:
+                name: catenax-managed-identity-wallets
+                port:
+                  number: 8000
+    - host: {{ .Values.certificate.host }}
+      port:
+        number: 8003
+      http:
+        paths:
+          - path:
+            backend:
+              service:
+                name: catenax-managed-identity-wallets
+                port:
+                  number: 8003
   tls:
     - hosts:
         - {{ .Values.certificate.host }}

--- a/charts/managed-identity-wallets/templates/ingress.yaml
+++ b/charts/managed-identity-wallets/templates/ingress.yaml
@@ -33,6 +33,9 @@ spec:
                 name: catenax-managed-identity-wallets
                 port:
                   number: 8080
+    # TODO Acapy inbound calls should be forwared to 8000 and 8003. This is related 
+    # to the values acapy.endorser.endpointUrl and acapy.mt.endpointUrl.
+    # Mabye a new host is required to achive this
   tls:
     - hosts:
         - {{ .Values.certificate.host }}

--- a/charts/managed-identity-wallets/templates/ingress.yaml
+++ b/charts/managed-identity-wallets/templates/ingress.yaml
@@ -16,6 +16,10 @@ metadata:
               deny all;
               return 403;
             }
+          location ~* /webhook/topic/ {
+            deny all;
+            return 403;
+          }
 
     # If you encounter a redirect loop or are getting a 307 response code
     # then you need to force the nginx ingress to connect to the backend using HTTPS.

--- a/charts/managed-identity-wallets/templates/secrets.yaml
+++ b/charts/managed-identity-wallets/templates/secrets.yaml
@@ -6,14 +6,22 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 stringData:
-  acapy-admin-api-key: {{ .Values.acapy.secret.apikey | quote }}
-  acapy-agent-wallet-seed: {{ .Values.acapy.secret.walletseed | quote }}
-  acapy-db-account: {{ .Values.acapy.secret.dbaccount | quote }}
-  acapy-db-admin: {{ .Values.acapy.secret.dbadminuser | quote }}
-  acapy-db-admin-password: {{ .Values.acapy.secret.dbadminpassword | quote }}
-  acapy-db-password: {{ .Values.acapy.secret.dbpassword | quote }}
-  acapy-jwt-secret: {{ .Values.acapy.secret.jwtsecret | quote }}
-  acapy-wallet-key: {{ .Values.acapy.secret.walletkey | quote }}
+  acapy-endorser-admin-api-key: {{ .Values.acapy.endorser.secret.apikey | quote }}
+  acapy-endorser-agent-wallet-seed: {{ .Values.acapy.endorser.secret.walletseed | quote }}
+  acapy-endorser-db-account: {{ .Values.acapy.endorser.secret.dbaccount | quote }}
+  acapy-endorser-db-admin: {{ .Values.acapy.endorser.secret.dbadminuser | quote }}
+  acapy-endorser-db-admin-password: {{ .Values.acapy.endorser.secret.dbadminpassword | quote }}
+  acapy-endorser-db-password: {{ .Values.acapy.endorser.secret.dbpassword | quote }}
+  acapy-endorser-jwt-secret: {{ .Values.acapy.endorser.secret.jwtsecret | quote }}
+  acapy-endorser-wallet-key: {{ .Values.acapy.endorser.secret.walletkey | quote }}
+  acapy-mt-admin-api-key: {{ .Values.acapy.mt.secret.apikey | quote }}
+  acapy-mt-agent-wallet-seed: {{ .Values.acapy.mt.secret.walletseed | quote }}
+  acapy-mt-db-account: {{ .Values.acapy.mt.secret.dbaccount | quote }}
+  acapy-mt-db-admin: {{ .Values.acapy.mt.secret.dbadminuser | quote }}
+  acapy-mt-db-admin-password: {{ .Values.acapy.mt.secret.dbadminpassword | quote }}
+  acapy-mt-db-password: {{ .Values.acapy.mt.secret.dbpassword | quote }}
+  acapy-mt-jwt-secret: {{ .Values.acapy.mt.secret.jwtsecret | quote }}
+  acapy-mt-wallet-key: {{ .Values.acapy.mt.secret.walletkey | quote }}
 {{- end}}
 {{- if not .Values.isLocal }}
 ---

--- a/charts/managed-identity-wallets/templates/service.yaml
+++ b/charts/managed-identity-wallets/templates/service.yaml
@@ -9,3 +9,25 @@ spec:
   - port: 8080
   selector:
     {{- include "managed-identity-wallets.selectorLabels" . | nindent 6 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: catenax-managed-identity-wallets-acapy-base
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8000  
+  selector:
+    {{- include "managed-identity-wallets.selectorLabels" . | nindent 6 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: catenax-managed-identity-wallets-acapy-mt
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8003
+  selector:
+    {{- include "managed-identity-wallets.selectorLabels" . | nindent 6 }}

--- a/charts/managed-identity-wallets/templates/service.yaml
+++ b/charts/managed-identity-wallets/templates/service.yaml
@@ -6,14 +6,6 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - name: catenax-managed-identity-wallets-miw
-    port: 8080
-    targetPort: 8080
-  - name: catenax-managed-identity-wallets-acapy-endorser
-    port: 8000
-    targetPort: 8000
-  - name: catenax-managed-identity-wallets-acapy-mt
-    port: 8003
-    targetPort: 8003
+  - port: 8080
   selector:
     {{- include "managed-identity-wallets.selectorLabels" . | nindent 6 }}

--- a/charts/managed-identity-wallets/templates/service.yaml
+++ b/charts/managed-identity-wallets/templates/service.yaml
@@ -6,13 +6,13 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - name: miw
+  - name: catenax-managed-identity-wallets-miw
     port: 8080
     targetPort: 8080
-  - name: acapy-endorser
+  - name: catenax-managed-identity-wallets-acapy-endorser
     port: 8000
     targetPort: 8000
-  - name: acapy-mt
+  - name: catenax-managed-identity-wallets-acapy-mt
     port: 8003
     targetPort: 8003
   selector:

--- a/charts/managed-identity-wallets/templates/service.yaml
+++ b/charts/managed-identity-wallets/templates/service.yaml
@@ -7,5 +7,7 @@ spec:
   type: ClusterIP
   ports:
   - port: 8080
+  - port: 8000
+  - port: 8003
   selector:
     {{- include "managed-identity-wallets.selectorLabels" . | nindent 6 }}

--- a/charts/managed-identity-wallets/templates/service.yaml
+++ b/charts/managed-identity-wallets/templates/service.yaml
@@ -6,8 +6,14 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - port: 8080
-  - port: 8000
-  - port: 8003
+  - name: miw
+    port: 8080
+    targetPort: 8080
+  - name: acapy-endorser
+    port: 8000
+    targetPort: 8000
+  - name: acapy-mt
+    port: 8003
+    targetPort: 8003
   selector:
     {{- include "managed-identity-wallets.selectorLabels" . | nindent 6 }}

--- a/charts/managed-identity-wallets/values-dev.yaml
+++ b/charts/managed-identity-wallets/values-dev.yaml
@@ -23,7 +23,7 @@ acapy:
   endorser:
     logLevel: "DEBUG"
     ledgerUrl: "http://dev.greenlight.bcovrin.vonx.io"
-    endpointUrl: "https://managed-identity-wallets.dev.demo.catena-x.net:8000/"
+    endpointUrl: "https://managed-identity-wallets.dev.demo.catena-x.net/acapy-connection-base"
     secret:
       apikey: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-endorser-admin-api-key>
       walletseed: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-endorser-agent-wallet-seed>
@@ -36,7 +36,7 @@ acapy:
   mt:
     logLevel: "DEBUG"
     ledgerUrl: "http://dev.greenlight.bcovrin.vonx.io"
-    endpointUrl: "https://managed-identity-wallets.dev.demo.catena-x.net:8003/"
+    endpointUrl: "https://managed-identity-wallets.dev.demo.catena-x.net/acapy-connection-mt"
     endorserPublicDid: "MhLrwtKpZhNCzazMeofPQH"
     secret:
       apikey: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-mt-admin-api-key>

--- a/charts/managed-identity-wallets/values-dev.yaml
+++ b/charts/managed-identity-wallets/values-dev.yaml
@@ -3,7 +3,8 @@ auth:
   issuerUrl: "https://centralidp.dev.demo.catena-x.net/auth/realms/CX-Central"
   redirectUrl: "https://managed-identity-wallets.dev.demo.catena-x.net/callback"
 image:
-  tag: "3.0.0-rc" # "latest-develop"
+  # tag: "latest-develop"
+  tag: "3.0.0-rc"
 wallet:
   baseWalletBpn: "BPNL000000000000"
   baseWalletShortDid: "MhLrwtKpZhNCzazMeofPQH"

--- a/charts/managed-identity-wallets/values-dev.yaml
+++ b/charts/managed-identity-wallets/values-dev.yaml
@@ -23,7 +23,7 @@ acapy:
   endorser:
     logLevel: "DEBUG"
     ledgerUrl: "http://dev.greenlight.bcovrin.vonx.io"
-    endpointUrl: "https://managed-identity-wallets.dev.demo.catena-x.net/acapy-connection-base"
+    endpointUrl: "https://managed-identity-wallets.dev.demo.catena-x.net/didcomm-base"
     secret:
       apikey: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-endorser-admin-api-key>
       walletseed: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-endorser-agent-wallet-seed>
@@ -36,7 +36,7 @@ acapy:
   mt:
     logLevel: "DEBUG"
     ledgerUrl: "http://dev.greenlight.bcovrin.vonx.io"
-    endpointUrl: "https://managed-identity-wallets.dev.demo.catena-x.net/acapy-connection-mt"
+    endpointUrl: "https://managed-identity-wallets.dev.demo.catena-x.net/didcomm-managed-wallets"
     endorserPublicDid: "MhLrwtKpZhNCzazMeofPQH"
     secret:
       apikey: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-mt-admin-api-key>

--- a/charts/managed-identity-wallets/values-dev.yaml
+++ b/charts/managed-identity-wallets/values-dev.yaml
@@ -56,11 +56,11 @@ managedIdentityWallets:
     bpdmauthclientsecret: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-secrets#bpdm-auth-client-secret>
 postgresql:
   secret:
-    password: <path:managed-identity-wallets/data/pen/postgres-managed-identity-wallets-secret-config#password>
-    postgrespassword: <path:managed-identity-wallets/data/pen/postgres-managed-identity-wallets-secret-config#postgres-password>
-    user: <path:managed-identity-wallets/data/pen/postgres-managed-identity-wallets-secret-config#user>
+    password: <path:managed-identity-wallets/data/dev/postgres-managed-identity-wallets-secret-config#password>
+    postgrespassword: <path:managed-identity-wallets/data/dev/postgres-managed-identity-wallets-secret-config#postgres-password>
+    user: <path:managed-identity-wallets/data/dev/postgres-managed-identity-wallets-secret-config#user>
 acapypostgresql:
   secret:
-    password: <path:managed-identity-wallets/data/pen/postgres-acapy-secret-config#password>
-    postgrespassword: <path:managed-identity-wallets/data/pen/postgres-acapy-secret-config#postgres-password>
-    user: <path:managed-identity-wallets/data/pen/postgres-acapy-secret-config#user>
+    password: <path:managed-identity-wallets/data/dev/postgres-acapy-secret-config#password>
+    postgrespassword: <path:managed-identity-wallets/data/dev/postgres-acapy-secret-config#postgres-password>
+    user: <path:managed-identity-wallets/data/dev/postgres-acapy-secret-config#user>

--- a/charts/managed-identity-wallets/values-dev.yaml
+++ b/charts/managed-identity-wallets/values-dev.yaml
@@ -3,7 +3,7 @@ auth:
   issuerUrl: "https://centralidp.dev.demo.catena-x.net/auth/realms/CX-Central"
   redirectUrl: "https://managed-identity-wallets.dev.demo.catena-x.net/callback"
 image:
-  tag: "latest-develop"
+  tag: "3.0.0-rc" # "latest-develop"
 wallet:
   baseWalletBpn: "BPNL000000000000"
   baseWalletShortDid: "MhLrwtKpZhNCzazMeofPQH"

--- a/charts/managed-identity-wallets/values-dev.yaml
+++ b/charts/managed-identity-wallets/values-dev.yaml
@@ -2,8 +2,6 @@ auth:
   jwksUrl: "https://centralidp.dev.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/certs"
   issuerUrl: "https://centralidp.dev.demo.catena-x.net/auth/realms/CX-Central"
   redirectUrl: "https://managed-identity-wallets.dev.demo.catena-x.net/callback"
-image:
-  tag: "3.0.0-rc"
 wallet:
   baseWalletBpn: "BPNL000000000000"
   baseWalletShortDid: "MhLrwtKpZhNCzazMeofPQH"

--- a/charts/managed-identity-wallets/values-dev.yaml
+++ b/charts/managed-identity-wallets/values-dev.yaml
@@ -3,7 +3,6 @@ auth:
   issuerUrl: "https://centralidp.dev.demo.catena-x.net/auth/realms/CX-Central"
   redirectUrl: "https://managed-identity-wallets.dev.demo.catena-x.net/callback"
 image:
-  # tag: "latest-develop"
   tag: "3.0.0-rc"
 wallet:
   baseWalletBpn: "BPNL000000000000"

--- a/charts/managed-identity-wallets/values-dev.yaml
+++ b/charts/managed-identity-wallets/values-dev.yaml
@@ -4,6 +4,11 @@ auth:
   redirectUrl: "https://managed-identity-wallets.dev.demo.catena-x.net/callback"
 image:
   tag: "latest-develop"
+wallet:
+  baseWalletBpn: "BPNL000000000000"
+  baseWalletShortDid: "QW5of989kdUeizZvWPPvZk" # TODO replace-with-did-of-endorser
+  baseWalletVerkey: "DovjfWCP4Ebw8CU7Uk93PpeaKXSiic4KAoGANxp9o15w" # TODO replace-with-verkey-of-endorser
+  baseWalletName: "Catena-X-Dev"   
 datapool:
   url: "https://partners-pool.dev.demo.catena-x.net"
   authUrl: "https://centralidp.dev.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
@@ -15,18 +20,33 @@ ingress:
 certificate: 
   host: "managed-identity-wallets.dev.demo.catena-x.net"
 acapy:
-  logLevel: "DEBUG"
-  ledgerUrl: "http://dev.greenlight.bcovrin.vonx.io"
-  endpointUrl: "https://managed-identity-wallets.dev.demo.catena-x.net:8000/"
-  secret:
-    apikey: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-admin-api-key>
-    walletseed: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-agent-wallet-seed>
-    dbaccount: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-db-account>
-    dbadminuser: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-db-admin>
-    dbadminpassword: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-db-admin-password>
-    dbpassword: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-db-password>
-    jwtsecret: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-jwt-secret>
-    walletkey: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-wallet-key>
+  endorser:
+    logLevel: "DEBUG"
+    ledgerUrl: "http://dev.greenlight.bcovrin.vonx.io"
+    endpointUrl: "https://managed-identity-wallets.dev.demo.catena-x.net:8000/"
+    secret:
+      apikey: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-admin-api-key>
+      walletseed: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-agent-wallet-seed>
+      dbaccount: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-db-account>
+      dbadminuser: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-db-admin>
+      dbadminpassword: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-db-admin-password>
+      dbpassword: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-db-password>
+      jwtsecret: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-jwt-secret>
+      walletkey: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-wallet-key>
+  mt:
+    logLevel: "DEBUG"
+    ledgerUrl: "http://dev.greenlight.bcovrin.vonx.io"
+    endpointUrl: "https://managed-identity-wallets.dev.demo.catena-x.net:8003/"
+    endorserPublicDid: "QW5of989kdUeizZvWPPvZk" # TODO replace-with-did-of-endorser
+    secret:
+      apikey: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-admin-api-key>
+      walletseed: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-agent-wallet-seed>
+      dbaccount: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-db-account>
+      dbadminuser: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-db-admin>
+      dbadminpassword: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-db-admin-password>
+      dbpassword: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-db-password>
+      jwtsecret: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-jwt-secret>
+      walletkey: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-wallet-key>
 managedIdentityWallets:
   secret:
     jdbcurl: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-secrets#cx-db-jdbc-url>

--- a/charts/managed-identity-wallets/values-dev.yaml
+++ b/charts/managed-identity-wallets/values-dev.yaml
@@ -6,8 +6,8 @@ image:
   tag: "latest-develop"
 wallet:
   baseWalletBpn: "BPNL000000000000"
-  baseWalletShortDid: "QW5of989kdUeizZvWPPvZk" # TODO replace-with-did-of-endorser
-  baseWalletVerkey: "DovjfWCP4Ebw8CU7Uk93PpeaKXSiic4KAoGANxp9o15w" # TODO replace-with-verkey-of-endorser
+  baseWalletShortDid: "MhLrwtKpZhNCzazMeofPQH"
+  baseWalletVerkey: "CHEC4PRQmP73A9UD7vQ6tnLAm9aoXLPhEtnGSMiAyVZj"
   baseWalletName: "Catena-X-Dev"   
 datapool:
   url: "https://partners-pool.dev.demo.catena-x.net"
@@ -25,28 +25,28 @@ acapy:
     ledgerUrl: "http://dev.greenlight.bcovrin.vonx.io"
     endpointUrl: "https://managed-identity-wallets.dev.demo.catena-x.net:8000/"
     secret:
-      apikey: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-admin-api-key>
-      walletseed: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-agent-wallet-seed>
-      dbaccount: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-db-account>
-      dbadminuser: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-db-admin>
-      dbadminpassword: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-db-admin-password>
-      dbpassword: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-db-password>
-      jwtsecret: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-jwt-secret>
-      walletkey: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-wallet-key>
+      apikey: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-endorser-admin-api-key>
+      walletseed: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-endorser-agent-wallet-seed>
+      dbaccount: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-endorser-db-account>
+      dbadminuser: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-endorser-db-admin>
+      dbadminpassword: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-endorser-db-admin-password>
+      dbpassword: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-endorser-db-password>
+      jwtsecret: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-endorser-jwt-secret>
+      walletkey: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-endorser-wallet-key>
   mt:
     logLevel: "DEBUG"
     ledgerUrl: "http://dev.greenlight.bcovrin.vonx.io"
     endpointUrl: "https://managed-identity-wallets.dev.demo.catena-x.net:8003/"
-    endorserPublicDid: "QW5of989kdUeizZvWPPvZk" # TODO replace-with-did-of-endorser
+    endorserPublicDid: "MhLrwtKpZhNCzazMeofPQH"
     secret:
-      apikey: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-admin-api-key>
-      walletseed: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-agent-wallet-seed>
-      dbaccount: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-db-account>
-      dbadminuser: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-db-admin>
-      dbadminpassword: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-db-admin-password>
-      dbpassword: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-db-password>
-      jwtsecret: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-jwt-secret>
-      walletkey: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-wallet-key>
+      apikey: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-mt-admin-api-key>
+      walletseed: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-mt-agent-wallet-seed>
+      dbaccount: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-mt-db-account>
+      dbadminuser: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-mt-db-admin>
+      dbadminpassword: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-mt-db-admin-password>
+      dbpassword: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-mt-db-password>
+      jwtsecret: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-mt-jwt-secret>
+      walletkey: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-acapy-secrets#acapy-mt-wallet-key>
 managedIdentityWallets:
   secret:
     jdbcurl: <path:managed-identity-wallets/data/dev/catenax-managed-identity-wallets-secrets#cx-db-jdbc-url>

--- a/charts/managed-identity-wallets/values-int.yaml
+++ b/charts/managed-identity-wallets/values-int.yaml
@@ -2,6 +2,11 @@ auth:
   jwksUrl: "https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/certs"
   issuerUrl: "https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central"
   redirectUrl: "https://managed-identity-wallets.int.demo.catena-x.net/callback"
+wallet:
+  baseWalletBpn: "BPNL000000000000"
+  baseWalletShortDid: "2xcjN7LjnHGaPdZbbGqju5"
+  baseWalletVerkey: "24vdNRCEY5Pswwv3XhbVSccbZA5r4ybxnYVGw3Q6WZjL"
+  baseWalletName: "Catena-X-Int"   
 datapool:
   url: "https://partners-pool.int.demo.catena-x.net"
   authUrl: "https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
@@ -13,17 +18,29 @@ ingress:
 certificate:
   host: "managed-identity-wallets.int.demo.catena-x.net"
 acapy:
-  endpointUrl: "https://managed-identity-wallets.int.demo.catena-x.net:8000/"
-  adminUrl: "http://localhost:11000"
-  secret:
-    apikey: <path:managed-identity-wallets/data/int/catenax-managed-identity-wallets-acapy-secrets#acapy-admin-api-key>
-    walletseed: <path:managed-identity-wallets/data/int/catenax-managed-identity-wallets-acapy-secrets#acapy-agent-wallet-seed>
-    dbaccount: <path:managed-identity-wallets/data/int/catenax-managed-identity-wallets-acapy-secrets#acapy-db-account>
-    dbadminuser: <path:managed-identity-wallets/data/int/catenax-managed-identity-wallets-acapy-secrets#acapy-db-admin>
-    dbadminpassword: <path:managed-identity-wallets/data/int/catenax-managed-identity-wallets-acapy-secrets#acapy-db-admin-password>
-    dbpassword: <path:managed-identity-wallets/data/int/catenax-managed-identity-wallets-acapy-secrets#acapy-db-password>
-    jwtsecret: <path:managed-identity-wallets/data/int/catenax-managed-identity-wallets-acapy-secrets#acapy-jwt-secret>
-    walletkey: <path:managed-identity-wallets/data/int/catenax-managed-identity-wallets-acapy-secrets#acapy-wallet-key>
+  endorser:
+    endpointUrl: "https://managed-identity-wallets.int.demo.catena-x.net/didcomm-base"
+    secret:
+      apikey: <path:managed-identity-wallets/data/int/catenax-managed-identity-wallets-acapy-secrets#acapy-endorser-admin-api-key>
+      walletseed: <path:managed-identity-wallets/data/int/catenax-managed-identity-wallets-acapy-secrets#acapy-endorser-agent-wallet-seed>
+      dbaccount: <path:managed-identity-wallets/data/int/catenax-managed-identity-wallets-acapy-secrets#acapy-endorser-db-account>
+      dbadminuser: <path:managed-identity-wallets/data/int/catenax-managed-identity-wallets-acapy-secrets#acapy-endorser-db-admin>
+      dbadminpassword: <path:managed-identity-wallets/data/int/catenax-managed-identity-wallets-acapy-secrets#acapy-endorser-db-admin-password>
+      dbpassword: <path:managed-identity-wallets/data/int/catenax-managed-identity-wallets-acapy-secrets#acapy-endorser-db-password>
+      jwtsecret: <path:managed-identity-wallets/data/int/catenax-managed-identity-wallets-acapy-secrets#acapy-endorser-jwt-secret>
+      walletkey: <path:managed-identity-wallets/data/int/catenax-managed-identity-wallets-acapy-secrets#acapy-endorser-wallet-key>
+  mt:
+    endpointUrl: "https://managed-identity-wallets.int.demo.catena-x.net/didcomm-managed-wallets"
+    endorserPublicDid: "2xcjN7LjnHGaPdZbbGqju5"
+    secret:
+      apikey: <path:managed-identity-wallets/data/int/catenax-managed-identity-wallets-acapy-secrets#acapy-mt-admin-api-key>
+      walletseed: <path:managed-identity-wallets/data/int/catenax-managed-identity-wallets-acapy-secrets#acapy-mt-agent-wallet-seed>
+      dbaccount: <path:managed-identity-wallets/data/int/catenax-managed-identity-wallets-acapy-secrets#acapy-mt-db-account>
+      dbadminuser: <path:managed-identity-wallets/data/int/catenax-managed-identity-wallets-acapy-secrets#acapy-mt-db-admin>
+      dbadminpassword: <path:managed-identity-wallets/data/int/catenax-managed-identity-wallets-acapy-secrets#acapy-mt-db-admin-password>
+      dbpassword: <path:managed-identity-wallets/data/int/catenax-managed-identity-wallets-acapy-secrets#acapy-mt-db-password>
+      jwtsecret: <path:managed-identity-wallets/data/int/catenax-managed-identity-wallets-acapy-secrets#acapy-mt-jwt-secret>
+      walletkey: <path:managed-identity-wallets/data/int/catenax-managed-identity-wallets-acapy-secrets#acapy-mt-wallet-key>
 managedIdentityWallets:
   secret:
     jdbcurl: <path:managed-identity-wallets/data/int/catenax-managed-identity-wallets-secrets#cx-db-jdbc-url>

--- a/charts/managed-identity-wallets/values.yaml
+++ b/charts/managed-identity-wallets/values.yaml
@@ -62,7 +62,7 @@ acapy:
     endpointPort: "8003"
     adminPort: "11003"
     adminUrl: "http://localhost:11003"
-    endorserPublicDid: "QW5of989kdUeizZvWPPvZk"
+    endorserPublicDid: "MhLrwtKpZhNCzazMeofPQH"
     webhookUrl: "http://localhost:8080/webhook"
     secret:
       apikey: "0"

--- a/charts/managed-identity-wallets/values.yaml
+++ b/charts/managed-identity-wallets/values.yaml
@@ -4,9 +4,9 @@ auth:
   roleMappings: "create_wallets:add_wallets,view_wallets:view_wallets,update_wallets:update_wallets,delete_wallets:delete_wallets,view_wallet:view_wallet,update_wallet:update_wallet"
   resourceId: "Cl5-CX-Custodian"
 image:
-  name: "catenax-ng/product-core-managed-identity-wallets_service"
+  name: "catenax-ng/tx-managed-identity-wallets_service"
   registry: "ghcr.io"
-  tag: "3.0.0-rc"
+  tag: "3.0.0"
   secret: "acr-credentials"
 allowEmptyPassword: "\"yes\""
 db:

--- a/charts/managed-identity-wallets/values.yaml
+++ b/charts/managed-identity-wallets/values.yaml
@@ -15,6 +15,9 @@ logging:
   exposed: "INFO"
 wallet:
   baseWalletBpn: "BPNL000000000000"
+  baseWalletShortDid: "QW5of989kdUeizZvWPPvZk"
+  baseWalletVerkey: "DovjfWCP4Ebw8CU7Uk93PpeaKXSiic4KAoGANxp9o15w"
+  baseWalletName: "Catena-X"  
 revocation:
   refreshHour: "3"
   revocationServiceUrl: http://localhost:8086
@@ -29,23 +32,44 @@ revocationService:
 acapy:
   imageName: "bcgovimages/aries-cloudagent"
   tag: "py36-1.16-1_0.7.4"
-  ledgerUrl: "https://idu.cloudcompass.ca"
-  label: "CatenaXIssuer"
-  logLevel: "INFO"
-  networkIdentifier: "idunion:test"
-  databaseHost: "acapypostgresql"
-  endpointPort: "8000"
-  adminPort: "11000"
-  adminUrl: "http://localhost:11000"
-  secret:
-    apikey: "0"
-    walletseed: "0"
-    dbaccount: "postgres"
-    dbadminuser: "postgres"
-    dbadminpassword: "postgres"
-    dbpassword: "postgres"
-    jwtsecret: "0"
-    walletkey: "0"
+  endorser: # AcaPy endorser instance
+    ledgerUrl: "https://idu.cloudcompass.ca"
+    label: "CatenaXIssuer"
+    logLevel: "INFO"
+    networkIdentifier: "idunion:test"
+    databaseHost: "acapypostgresql"
+    endpointPort: "8000"
+    adminPort: "11000"
+    adminUrl: "http://localhost:11000"
+    secret:
+      apikey: "0"
+      walletseed: "0"
+      dbaccount: "postgres"
+      dbadminuser: "postgres" 
+      dbadminpassword: "postgres"
+      dbpassword: "postgres"
+      jwtsecret: "0"
+      walletkey: "0"
+  mt: # AcaPy multi-tenancy instance
+    ledgerUrl: "https://idu.cloudcompass.ca"
+    label: "CatenaXIssuer"
+    logLevel: "INFO"
+    networkIdentifier: "idunion:test"
+    databaseHost: "acapypostgresql"
+    endpointPort: "8003"
+    adminPort: "11003"
+    adminUrl: "http://localhost:11003"
+    endorserPublicDid: "QW5of989kdUeizZvWPPvZk"
+    webhookUrl: "http://localhost:8080/webhook"
+    secret:
+      apikey: "0"
+      walletseed: "0"
+      dbaccount: "postgres"
+      dbadminuser: "postgres"
+      dbadminpassword: "postgres"
+      dbpassword: "postgres"
+      jwtsecret: "0"
+      walletkey: "0"
 ingress:
   enabled: false
 acapypostgresql:

--- a/charts/managed-identity-wallets/values.yaml
+++ b/charts/managed-identity-wallets/values.yaml
@@ -4,9 +4,9 @@ auth:
   roleMappings: "create_wallets:add_wallets,view_wallets:view_wallets,update_wallets:update_wallets,delete_wallets:delete_wallets,view_wallet:view_wallet,update_wallet:update_wallet"
   resourceId: "Cl5-CX-Custodian"
 image:
-  name: "eclipse-tractusx/managed-identity-wallets_service"
+  name: "catenax-ng/product-core-managed-identity-wallets_service"
   registry: "ghcr.io"
-  tag: "3.0.0-develop"
+  tag: "3.0.0-rc" #"3.0.0-develop"
   secret: "acr-credentials"
 allowEmptyPassword: "\"yes\""
 db:

--- a/charts/managed-identity-wallets/values.yaml
+++ b/charts/managed-identity-wallets/values.yaml
@@ -6,7 +6,8 @@ auth:
 image:
   name: "catenax-ng/product-core-managed-identity-wallets_service"
   registry: "ghcr.io"
-  tag: "3.0.0-rc" #"3.0.0-develop"
+  #"3.0.0-develop"
+  tag: "3.0.0-rc"
   secret: "acr-credentials"
 allowEmptyPassword: "\"yes\""
 db:

--- a/charts/managed-identity-wallets/values.yaml
+++ b/charts/managed-identity-wallets/values.yaml
@@ -31,7 +31,7 @@ revocationService:
   clientIssuanceApiUrl: "http://localhost:8080"
 acapy:
   imageName: "bcgovimages/aries-cloudagent"
-  tag: "py36-1.16-1_0.7.4"
+  tag: "py36-1.16-1_0.7.5"
   endorser: # AcaPy endorser instance
     ledgerUrl: "https://idu.cloudcompass.ca"
     label: "CatenaXIssuer"

--- a/charts/managed-identity-wallets/values.yaml
+++ b/charts/managed-identity-wallets/values.yaml
@@ -15,8 +15,8 @@ logging:
   exposed: "INFO"
 wallet:
   baseWalletBpn: "BPNL000000000000"
-  baseWalletShortDid: "QW5of989kdUeizZvWPPvZk"
-  baseWalletVerkey: "DovjfWCP4Ebw8CU7Uk93PpeaKXSiic4KAoGANxp9o15w"
+  baseWalletShortDid: "MhLrwtKpZhNCzazMeofPQH"
+  baseWalletVerkey: "CHEC4PRQmP73A9UD7vQ6tnLAm9aoXLPhEtnGSMiAyVZj"
   baseWalletName: "Catena-X"
 revocation:
   refreshHour: "3"

--- a/charts/managed-identity-wallets/values.yaml
+++ b/charts/managed-identity-wallets/values.yaml
@@ -4,7 +4,7 @@ auth:
   roleMappings: "create_wallets:add_wallets,view_wallets:view_wallets,update_wallets:update_wallets,delete_wallets:delete_wallets,view_wallet:view_wallet,update_wallet:update_wallet"
   resourceId: "Cl5-CX-Custodian"
 image:
-  name: "catenax-ng/product-core-managed-identity-wallets_service"
+  name: "eclipse-tractusx/managed-identity-wallets_service"
   registry: "ghcr.io"
   secret: "acr-credentials"
 allowEmptyPassword: "\"yes\""

--- a/charts/managed-identity-wallets/values.yaml
+++ b/charts/managed-identity-wallets/values.yaml
@@ -17,7 +17,7 @@ wallet:
   baseWalletBpn: "BPNL000000000000"
   baseWalletShortDid: "QW5of989kdUeizZvWPPvZk"
   baseWalletVerkey: "DovjfWCP4Ebw8CU7Uk93PpeaKXSiic4KAoGANxp9o15w"
-  baseWalletName: "Catena-X"  
+  baseWalletName: "Catena-X"
 revocation:
   refreshHour: "3"
   revocationServiceUrl: http://localhost:8086
@@ -32,7 +32,8 @@ revocationService:
 acapy:
   imageName: "bcgovimages/aries-cloudagent"
   tag: "py36-1.16-1_0.7.5"
-  endorser: # AcaPy endorser instance
+  # AcaPy endorser instance
+  endorser:
     ledgerUrl: "https://idu.cloudcompass.ca"
     label: "CatenaXIssuer"
     logLevel: "INFO"
@@ -45,12 +46,13 @@ acapy:
       apikey: "0"
       walletseed: "0"
       dbaccount: "postgres"
-      dbadminuser: "postgres" 
+      dbadminuser: "postgres"
       dbadminpassword: "postgres"
       dbpassword: "postgres"
       jwtsecret: "0"
       walletkey: "0"
-  mt: # AcaPy multi-tenancy instance
+  # AcaPy multi-tenancy instance
+  mt:
     ledgerUrl: "https://idu.cloudcompass.ca"
     label: "CatenaXIssuer"
     logLevel: "INFO"

--- a/charts/managed-identity-wallets/values.yaml
+++ b/charts/managed-identity-wallets/values.yaml
@@ -6,7 +6,6 @@ auth:
 image:
   name: "catenax-ng/product-core-managed-identity-wallets_service"
   registry: "ghcr.io"
-  #"3.0.0-develop"
   tag: "3.0.0-rc"
   secret: "acr-credentials"
 allowEmptyPassword: "\"yes\""

--- a/charts/managed-identity-wallets/values.yaml
+++ b/charts/managed-identity-wallets/values.yaml
@@ -6,6 +6,7 @@ auth:
 image:
   name: "eclipse-tractusx/managed-identity-wallets_service"
   registry: "ghcr.io"
+  tag: "3.0.0-develop"
   secret: "acr-credentials"
 allowEmptyPassword: "\"yes\""
 db:


### PR DESCRIPTION
`catenax-managed-identity-wallets-acapy-secrets` must be changed and new secrets keys and values must be added in the vault for acapy.endorser and acapy.mt.

each environment requires now 2 Acapy Seeds. The DID and Verkey of these Seeds must be registered on the ledger as endorser